### PR TITLE
DecimalFormatPatternParserNumber patterns removed comma separators

### DIFF
--- a/src/main/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumber.java
+++ b/src/main/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumber.java
@@ -317,6 +317,7 @@ final class DecimalFormatPatternParserNumber extends DecimalFormatPatternParser 
     public String toString() {
         return ToStringBuilder.empty()
                 .value(this.pattern)
+                .valueSeparator("")
                 .label("prefix").value(this.prefix)
                 .label("number").value(this.number)
                 .label("suffix").value(this.suffix)

--- a/src/test/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumberTest.java
+++ b/src/test/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumberTest.java
@@ -673,7 +673,7 @@ public final class DecimalFormatPatternParserNumberTest extends DecimalFormatPat
         final DecimalFormatPatternParserNumber parser = this.createParser("P#00S");
         parser.parse();
 
-        this.toStringAndCheck(parser, "\"P#00S\" prefix=P number=#, 0, 0 suffix=S");
+        this.toStringAndCheck(parser, "\"P#00S\" prefix=P number=#00 suffix=S");
     }
 
     @Test
@@ -681,7 +681,7 @@ public final class DecimalFormatPatternParserNumberTest extends DecimalFormatPat
         final DecimalFormatPatternParserNumber parser = this.createParser("P#00");
         parser.parse();
 
-        this.toStringAndCheck(parser, "\"P#00\" prefix=P number=#, 0, 0");
+        this.toStringAndCheck(parser, "\"P#00\" prefix=P number=#00");
     }
 
     // helpers..........................................................................................................


### PR DESCRIPTION
- previously prefix/number/suffix were comma separated, now toString form is everything joined separated by nothing.