### PR TITLE
DecimalFormat.applyPattern groupingSize

### DIFF
--- a/src/main/java/walkingkooka/javatextj2cl/java/text/DecimalFormat.java
+++ b/src/main/java/walkingkooka/javatextj2cl/java/text/DecimalFormat.java
@@ -380,7 +380,7 @@ public class DecimalFormat extends NumberFormat {
 
         boolean currency = positive.currency;
 
-        final int groupingSeparator = positive.groupingSeparator;
+        final int groupingSize = positive.groupingSize;
         final int multiplier = positive.multiplier;
 
         // String versions will be computed later.
@@ -421,8 +421,8 @@ public class DecimalFormat extends NumberFormat {
         }
 
         // commit pattern changes to this.
-        this.setGroupingSize(groupingSeparator);
-        this.setGroupingUsed(groupingSeparator > 0);
+        this.setGroupingSize(groupingSize);
+        this.setGroupingUsed(groupingSize > 0);
         this.setMultiplier(multiplier);
 
         this.maximumFractionDigits = positive.maximumFractionDigits;

--- a/src/main/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumber.java
+++ b/src/main/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumber.java
@@ -20,6 +20,7 @@ package walkingkooka.javatextj2cl.java.text;
 import walkingkooka.ToStringBuilder;
 import walkingkooka.collect.list.Lists;
 
+import java.text.DecimalFormat;
 import java.util.List;
 
 /**
@@ -92,7 +93,6 @@ final class DecimalFormatPatternParserNumber extends DecimalFormatPatternParser 
 
         this.number.add(DecimalFormatPatternComponent.exponent());
         this.setMode(DecimalFormatPatternParserNumberMode.EXPONENT);
-        this.checkGroupingSeparator();
         this.exponent = position;
     }
 
@@ -123,24 +123,36 @@ final class DecimalFormatPatternParserNumber extends DecimalFormatPatternParser 
 
     private void checkGroupingSeparator() {
         // if number ends in grouping its a bad pattern
-        final int groupingSeparator = this.computeGroupingSeparator();
-        if (0 == groupingSeparator) {
+        if (0 == this.groupingSize()) {
             this.failInvalidCharacter(this.groupingSeparator);
         }
     }
 
-    int computeGroupingSeparator() {
-        final List<DecimalFormatPatternComponent> number = this.number;
-        final int index = number.lastIndexOf(DecimalFormatPatternComponent.groupingSeparator());
-        return -1 == index ?
-                -1 :
-                number.size() - index - 1;
+    int groupingSize() {
+        if (-1 != this.groupingSeparator && -1 == this.groupingSize) {
+            final List<DecimalFormatPatternComponent> number = this.number;
+            int decimal = this.decimalSeparator;
+            if (-1 == decimal) {
+                decimal = number.size();
+            }
+
+            final int index = number.lastIndexOf(DecimalFormatPatternComponent.groupingSeparator());
+            this.groupingSize = -1 == index ?
+                    -1 :
+                    decimal - index - 1;
+        }
+        return this.groupingSize;
     }
 
     /**
      * Kept to help produce accurate {@link walkingkooka.InvalidCharacterException} messages.
      */
-    int groupingSeparator = -1;
+    private int groupingSeparator = -1;
+
+    /**
+     * The computed groupingSeparator for {@link DecimalFormat#getGroupingSize()}
+     */
+    int groupingSize = -1;
 
     // hash.............................................................................................................
 

--- a/src/test/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumberTest.java
+++ b/src/test/java/walkingkooka/javatextj2cl/java/text/DecimalFormatPatternParserNumberTest.java
@@ -781,7 +781,7 @@ public final class DecimalFormatPatternParserNumberTest extends DecimalFormatPat
 
     private void checkGroupingSeparator(final DecimalFormatPatternParserNumber parser,
                                         final int groupingSeparator) {
-        assertEquals(groupingSeparator, parser.computeGroupingSeparator(), () -> "groupingSeparator " + parser);
+        assertEquals(groupingSeparator, parser.groupingSize(), () -> "groupingSeparator " + parser);
     }
 
     private void checkFraction(final DecimalFormatPatternParserNumber parser,

--- a/src/test/java/walkingkooka/javatextj2cl/java/text/DecimalFormatTest.java
+++ b/src/test/java/walkingkooka/javatextj2cl/java/text/DecimalFormatTest.java
@@ -885,7 +885,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
         // the commented out tests will fail because the pattern is not parsed and the tested values not correctly set.
 
         assertEquals(jdk.getCurrency(), emul.getCurrency(), () -> "currency " + locale + " " + emul);
-//        assertEquals(jdk.getGroupingSize(), emul.getGroupingSize(), () -> "groupingSize " + locale + " " + emul);
+        assertEquals(jdk.getGroupingSize(), emul.getGroupingSize(), () -> "groupingSize " + locale + " " + emul);
         assertEquals(jdk.isGroupingUsed(), emul.isGroupingUsed(), () -> "groupingUsed " + locale + " " + emul);
         assertEquals(jdk.getMaximumFractionDigits(), emul.getMaximumFractionDigits(), () -> "maximumFractionDigits " + locale + " " + emul);
         assertEquals(jdk.getMinimumFractionDigits(), emul.getMinimumFractionDigits(), () -> "minimumFractionDigits " + locale + " " + emul);


### PR DESCRIPTION
- Fixed DecimalFormatPatternParserNumber.groupingSize computation.
- Removed unnecessary checkGroupingSeparator call

- Closes #113 